### PR TITLE
int32 overflow fix

### DIFF
--- a/2021/day16-2.py
+++ b/2021/day16-2.py
@@ -1,5 +1,5 @@
 from typing import Tuple, List
-import numpy as np
+import functools
 
 
 def read_input() -> str:
@@ -86,7 +86,7 @@ def process_message(message: str, indent="") -> Tuple[int, str]:
     if type == 0:
         return sum(packet_values), message
     elif type == 1:
-        return np.prod(packet_values), message
+        return functools.reduce(lambda a, b: a*b, packet_values), message
     elif type == 2:
         return min(packet_values), message
     elif type == 3:


### PR DESCRIPTION
I have observed that the solution of [day 16 part 2](https://github.com/TessFerrandez/AdventOfCode-Python/blob/develop/2021/day16-2.py) is vulnerable for integer overflow. Namely the hex input string: `26008C8E2DA0191C5B400` represents the data of the form:
```json
{
   "version":1,
   "id":1,
   "operator_data":[
      {
         "version":1,
         "id":4,
         "value":100000
      },
      {
         "version":1,
         "id":4,
         "value":100000
      }
   ]
}
```
which should evaluate to `10000000000` which is not `1410065408`. This situation occurs in the case of [_my_ full input](https://github.com/vil02/adv_2021/blob/master/tests/test_input_data/data_adv_2021_16_p.txt), which should evaluate to [`5390807940351`](https://github.com/vil02/adv_2021/blob/7310f47e7fd50a57463e2f7c8b88c2b1331d4768/tests/test_adv_2021_16.py#L120).

The reason of this behaviour is the line:
https://github.com/TessFerrandez/AdventOfCode-Python/blob/f0857ea2dcba1ab812789e915582f13f5db045be/2021/day16-2.py#L89
where packet_values is being converted into `numpy.array` storing `int32`.

This pull-request contains a fix of this issue by replacing the way how the product of an array is being computed.